### PR TITLE
Add duplicate file logging and tests

### DIFF
--- a/DOPipeline/Logging/FileConsoleLogger.cs
+++ b/DOPipeline/Logging/FileConsoleLogger.cs
@@ -23,7 +23,12 @@ namespace DOPipeline.Logging
                 }
 
                 // Open the file for appending, create if it doesn't exist
-                _streamWriter = new StreamWriter(_logFilePath, append: true) { AutoFlush = true };
+                var fileStream = new FileStream(
+                    _logFilePath,
+                    FileMode.Append,
+                    FileAccess.Write,
+                    FileShare.ReadWrite);
+                _streamWriter = new StreamWriter(fileStream) { AutoFlush = true };
             }
             catch (Exception ex)
             {

--- a/DifferentialBackup.Test/Helpers/TestFileHelpers.cs
+++ b/DifferentialBackup.Test/Helpers/TestFileHelpers.cs
@@ -1,0 +1,14 @@
+using System.IO;
+
+namespace DifferentialBackup.Test.Helpers
+{
+    public static class TestFileHelpers
+    {
+        public static string ReadAllTextShared(string path)
+        {
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+            using var reader = new StreamReader(fs);
+            return reader.ReadToEnd();
+        }
+    }
+}

--- a/DifferentialBackup.Test/Pipeline/DuplicateDetectionPipelineBuilderTests.cs
+++ b/DifferentialBackup.Test/Pipeline/DuplicateDetectionPipelineBuilderTests.cs
@@ -1,0 +1,76 @@
+using Xunit;
+using DifferentialBackup.Pipeline;
+using DifferentialBackup.Components;
+using DOPipeline.Entities;
+using DOPipeline.Storage;
+using DifferentialBackup.Test.Helpers;
+using DOPipeline.Logging;
+using System.IO;
+using System.Collections.Generic;
+
+namespace DifferentialBackup.Test.Pipeline
+{
+    public class DuplicateDetectionPipelineBuilderTests
+    {
+        private readonly IPipelineLogger _logger = NullLogger.Instance;
+
+        [Fact]
+        public void BuildDuplicateDetectionPipeline_CreatesPipeline()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "DupPipeBuildTest");
+            Directory.CreateDirectory(tempDir);
+            var pipeline = DuplicateDetectionPipelineBuilder.BuildDuplicateDetectionPipeline(tempDir, _logger);
+            Assert.NotNull(pipeline);
+            Directory.Delete(tempDir);
+        }
+
+        [Fact]
+        public void DuplicateDetectionPipeline_Execute_FindsDuplicates()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "DupPipeExecTest");
+            Directory.CreateDirectory(tempDir);
+            var logPath = Path.Combine(tempDir, "dup.log");
+            using var logger = new FileConsoleLogger(logPath);
+            var file1 = Path.Combine(tempDir, "a.txt");
+            var file2 = Path.Combine(tempDir, "b.txt");
+            var file3 = Path.Combine(tempDir, "c.txt");
+            var file4 = Path.Combine(tempDir, "d.txt");
+            File.WriteAllText(file1, "abc");
+            File.WriteAllText(file2, "abc");
+            File.WriteAllText(file3, "abc");
+            File.WriteAllText(file4, "xyz");
+
+            var pipeline = DuplicateDetectionPipelineBuilder.BuildDuplicateDetectionPipeline(tempDir, logger);
+            var storage = new ComponentStorage();
+            var root = new Entity();
+            storage.SetComponent(root, new FilePathComponent { FilePath = tempDir });
+            var entities = new List<Entity> { root };
+            var result = pipeline.Execute(entities, storage);
+            Assert.True(result.IsSuccess);
+            var dupComponent = storage.GetComponent<DuplicateFilesComponent>(root);
+            Assert.NotNull(dupComponent);
+            Assert.Single(dupComponent.Groups);
+            var group = dupComponent.Groups[0];
+            Assert.Contains(file1, group);
+            Assert.Contains(file2, group);
+            Assert.Contains(file3, group);
+            Assert.DoesNotContain(file4, group);
+
+            var logContents = File.ReadAllText(logPath);
+            Assert.Contains(file1, logContents);
+            Assert.Contains(file2, logContents);
+            Assert.Contains(file3, logContents);
+            Assert.DoesNotContain(file4, logContents);
+
+            foreach (var entity in storage.GetAllEntities())
+            {
+                if (entity != root && storage.HasComponent<FilePathComponent>(entity))
+                {
+                    Assert.Null(storage.GetComponent<DuplicateFilesComponent>(entity));
+                }
+            }
+
+            File.Delete(file1); File.Delete(file2); File.Delete(file3); File.Delete(file4); File.Delete(logPath); Directory.Delete(tempDir);
+        }
+    }
+}

--- a/DifferentialBackup.Test/Pipeline/DuplicateDetectionPipelineBuilderTests.cs
+++ b/DifferentialBackup.Test/Pipeline/DuplicateDetectionPipelineBuilderTests.cs
@@ -30,43 +30,45 @@ namespace DifferentialBackup.Test.Pipeline
             var tempDir = Path.Combine(Path.GetTempPath(), "DupPipeExecTest");
             Directory.CreateDirectory(tempDir);
             var logPath = Path.Combine(tempDir, "dup.log");
-            using var logger = new FileConsoleLogger(logPath);
             var file1 = Path.Combine(tempDir, "a.txt");
             var file2 = Path.Combine(tempDir, "b.txt");
             var file3 = Path.Combine(tempDir, "c.txt");
             var file4 = Path.Combine(tempDir, "d.txt");
-            File.WriteAllText(file1, "abc");
-            File.WriteAllText(file2, "abc");
-            File.WriteAllText(file3, "abc");
-            File.WriteAllText(file4, "xyz");
-
-            var pipeline = DuplicateDetectionPipelineBuilder.BuildDuplicateDetectionPipeline(tempDir, logger);
-            var storage = new ComponentStorage();
-            var root = new Entity();
-            storage.SetComponent(root, new FilePathComponent { FilePath = tempDir });
-            var entities = new List<Entity> { root };
-            var result = pipeline.Execute(entities, storage);
-            Assert.True(result.IsSuccess);
-            var dupComponent = storage.GetComponent<DuplicateFilesComponent>(root);
-            Assert.NotNull(dupComponent);
-            Assert.Single(dupComponent.Groups);
-            var group = dupComponent.Groups[0];
-            Assert.Contains(file1, group);
-            Assert.Contains(file2, group);
-            Assert.Contains(file3, group);
-            Assert.DoesNotContain(file4, group);
-
-            var logContents = File.ReadAllText(logPath);
-            Assert.Contains(file1, logContents);
-            Assert.Contains(file2, logContents);
-            Assert.Contains(file3, logContents);
-            Assert.DoesNotContain(file4, logContents);
-
-            foreach (var entity in storage.GetAllEntities())
+            using (var logger = new FileConsoleLogger(logPath))
             {
-                if (entity != root && storage.HasComponent<FilePathComponent>(entity))
+                File.WriteAllText(file1, "abc");
+                File.WriteAllText(file2, "abc");
+                File.WriteAllText(file3, "abc");
+                File.WriteAllText(file4, "xyz");
+
+                var pipeline = DuplicateDetectionPipelineBuilder.BuildDuplicateDetectionPipeline(tempDir, logger);
+                var storage = new ComponentStorage();
+                var root = new Entity();
+                storage.SetComponent(root, new FilePathComponent { FilePath = tempDir });
+                var entities = new List<Entity> { root };
+                var result = pipeline.Execute(entities, storage);
+                Assert.True(result.IsSuccess);
+                var dupComponent = storage.GetComponent<DuplicateFilesComponent>(root);
+                Assert.NotNull(dupComponent);
+                Assert.Single(dupComponent.Groups);
+                var group = dupComponent.Groups[0];
+                Assert.Contains(file1, group);
+                Assert.Contains(file2, group);
+                Assert.Contains(file3, group);
+                Assert.DoesNotContain(file4, group);
+
+                var logContents = TestFileHelpers.ReadAllTextShared(logPath);
+                Assert.Contains(file1, logContents);
+                Assert.Contains(file2, logContents);
+                Assert.Contains(file3, logContents);
+                Assert.DoesNotContain(file4, logContents);
+
+                foreach (var entity in storage.GetAllEntities())
                 {
-                    Assert.Null(storage.GetComponent<DuplicateFilesComponent>(entity));
+                    if (entity != root && storage.HasComponent<FilePathComponent>(entity))
+                    {
+                        Assert.Null(storage.GetComponent<DuplicateFilesComponent>(entity));
+                    }
                 }
             }
 

--- a/DifferentialBackup.Test/Systems/DuplicateDetectionSystemTests.cs
+++ b/DifferentialBackup.Test/Systems/DuplicateDetectionSystemTests.cs
@@ -1,0 +1,78 @@
+using Xunit;
+using DifferentialBackup.Systems;
+using DifferentialBackup.Components;
+using DOPipeline.Entities;
+using DOPipeline.Storage;
+using System.IO;
+using System.Collections.Concurrent;
+using DOPipeline.Logging;
+
+namespace DifferentialBackup.Test.Systems
+{
+    public class DuplicateDetectionSystemTests
+    {
+        [Fact]
+        public void Execute_FindsDuplicateFiles()
+        {
+            var tempDir = Path.Combine(Path.GetTempPath(), "DupDetectTest");
+            Directory.CreateDirectory(tempDir);
+            var file1 = Path.Combine(tempDir, "a.txt");
+            var file2 = Path.Combine(tempDir, "b.txt");
+            var file3 = Path.Combine(tempDir, "c.txt");
+            var file4 = Path.Combine(tempDir, "d.txt");
+            var logPath = Path.Combine(tempDir, "dup.log");
+            using var logger = new FileConsoleLogger(logPath);
+            File.WriteAllText(file1, "same");
+            File.WriteAllText(file2, "same");
+            File.WriteAllText(file3, "same");
+            File.WriteAllText(file4, "other");
+
+            var storage = new ComponentStorage();
+            var discovery = new FileDiscoverySystem(tempDir);
+            var fileHashes = new ConcurrentDictionary<string, string>();
+            var hashSystem = new HashCalculationSystem(fileHashes);
+            var root = new Entity();
+            storage.SetComponent(root, new FilePathComponent { FilePath = tempDir });
+            discovery.Execute(root, storage);
+
+            foreach (var entity in storage.GetAllEntities())
+            {
+                if (storage.HasComponent<FilePathComponent>(entity) && entity != root)
+                {
+                    hashSystem.Execute(entity, storage);
+                }
+            }
+
+            var dupSystem = new DuplicateDetectionSystem();
+            var result = dupSystem.Execute(root, storage);
+            Assert.True(result.IsSuccess);
+            var logSystem = new DuplicateLoggingSystem(logger);
+            var logResult = logSystem.Execute(root, storage);
+            Assert.True(logResult.IsSuccess);
+            var dupComponent = storage.GetComponent<DuplicateFilesComponent>(root);
+            Assert.NotNull(dupComponent);
+            Assert.Single(dupComponent.Groups);
+            var group = dupComponent.Groups[0];
+            Assert.Contains(file1, group);
+            Assert.Contains(file2, group);
+            Assert.Contains(file3, group);
+            Assert.DoesNotContain(file4, group);
+
+            var logContents = File.ReadAllText(logPath);
+            Assert.Contains(file1, logContents);
+            Assert.Contains(file2, logContents);
+            Assert.Contains(file3, logContents);
+            Assert.DoesNotContain(file4, logContents);
+
+            foreach (var entity in storage.GetAllEntities())
+            {
+                if (entity != root && storage.HasComponent<FilePathComponent>(entity))
+                {
+                    Assert.Null(storage.GetComponent<DuplicateFilesComponent>(entity));
+                }
+            }
+
+            File.Delete(file1); File.Delete(file2); File.Delete(file3); File.Delete(file4); File.Delete(logPath); Directory.Delete(tempDir);
+        }
+    }
+}

--- a/DifferentialBackup.Test/Systems/DuplicateDetectionSystemTests.cs
+++ b/DifferentialBackup.Test/Systems/DuplicateDetectionSystemTests.cs
@@ -6,6 +6,7 @@ using DOPipeline.Storage;
 using System.IO;
 using System.Collections.Concurrent;
 using DOPipeline.Logging;
+using DifferentialBackup.Test.Helpers;
 
 namespace DifferentialBackup.Test.Systems
 {
@@ -21,11 +22,12 @@ namespace DifferentialBackup.Test.Systems
             var file3 = Path.Combine(tempDir, "c.txt");
             var file4 = Path.Combine(tempDir, "d.txt");
             var logPath = Path.Combine(tempDir, "dup.log");
-            using var logger = new FileConsoleLogger(logPath);
-            File.WriteAllText(file1, "same");
-            File.WriteAllText(file2, "same");
-            File.WriteAllText(file3, "same");
-            File.WriteAllText(file4, "other");
+            using (var logger = new FileConsoleLogger(logPath))
+            {
+                File.WriteAllText(file1, "same");
+                File.WriteAllText(file2, "same");
+                File.WriteAllText(file3, "same");
+                File.WriteAllText(file4, "other");
 
             var storage = new ComponentStorage();
             var discovery = new FileDiscoverySystem(tempDir);
@@ -43,32 +45,33 @@ namespace DifferentialBackup.Test.Systems
                 }
             }
 
-            var dupSystem = new DuplicateDetectionSystem();
-            var result = dupSystem.Execute(root, storage);
-            Assert.True(result.IsSuccess);
-            var logSystem = new DuplicateLoggingSystem(logger);
-            var logResult = logSystem.Execute(root, storage);
-            Assert.True(logResult.IsSuccess);
-            var dupComponent = storage.GetComponent<DuplicateFilesComponent>(root);
-            Assert.NotNull(dupComponent);
-            Assert.Single(dupComponent.Groups);
-            var group = dupComponent.Groups[0];
-            Assert.Contains(file1, group);
-            Assert.Contains(file2, group);
-            Assert.Contains(file3, group);
-            Assert.DoesNotContain(file4, group);
+                var dupSystem = new DuplicateDetectionSystem();
+                var result = dupSystem.Execute(root, storage);
+                Assert.True(result.IsSuccess);
+                var logSystem = new DuplicateLoggingSystem(logger);
+                var logResult = logSystem.Execute(root, storage);
+                Assert.True(logResult.IsSuccess);
+                var dupComponent = storage.GetComponent<DuplicateFilesComponent>(root);
+                Assert.NotNull(dupComponent);
+                Assert.Single(dupComponent.Groups);
+                var group = dupComponent.Groups[0];
+                Assert.Contains(file1, group);
+                Assert.Contains(file2, group);
+                Assert.Contains(file3, group);
+                Assert.DoesNotContain(file4, group);
 
-            var logContents = File.ReadAllText(logPath);
-            Assert.Contains(file1, logContents);
-            Assert.Contains(file2, logContents);
-            Assert.Contains(file3, logContents);
-            Assert.DoesNotContain(file4, logContents);
+                var logContents = TestFileHelpers.ReadAllTextShared(logPath);
+                Assert.Contains(file1, logContents);
+                Assert.Contains(file2, logContents);
+                Assert.Contains(file3, logContents);
+                Assert.DoesNotContain(file4, logContents);
 
-            foreach (var entity in storage.GetAllEntities())
-            {
-                if (entity != root && storage.HasComponent<FilePathComponent>(entity))
+                foreach (var entity in storage.GetAllEntities())
                 {
-                    Assert.Null(storage.GetComponent<DuplicateFilesComponent>(entity));
+                    if (entity != root && storage.HasComponent<FilePathComponent>(entity))
+                    {
+                        Assert.Null(storage.GetComponent<DuplicateFilesComponent>(entity));
+                    }
                 }
             }
 

--- a/DifferentialBackup/Components/DuplicateFilesComponent.cs
+++ b/DifferentialBackup/Components/DuplicateFilesComponent.cs
@@ -1,0 +1,10 @@
+using DOPipeline.Components;
+using System.Collections.Generic;
+
+namespace DifferentialBackup.Components
+{
+    public class DuplicateFilesComponent : IComponent
+    {
+        public List<List<string>> Groups { get; set; } = new List<List<string>>();
+    }
+}

--- a/DifferentialBackup/Pipeline/DuplicateDetectionPipelineBuilder.cs
+++ b/DifferentialBackup/Pipeline/DuplicateDetectionPipelineBuilder.cs
@@ -1,0 +1,35 @@
+using DOPipeline.Builders;
+using DOPipeline.Logging;
+using DOPipeline.Pipeline;
+using DifferentialBackup.Systems;
+using System.Collections.Concurrent;
+
+namespace DifferentialBackup.Pipeline
+{
+    public static class DuplicateDetectionPipelineBuilder
+    {
+        public static DOPipeline.Pipeline.Pipeline BuildDuplicateDetectionPipeline(
+            string sourceDirectory,
+            IPipelineLogger logger)
+        {
+            var pipelineBuilder = new PipelineBuilder();
+            pipelineBuilder.WithLogger(logger);
+
+            pipelineBuilder.AddPipe(pb => pb
+                .Named("File Discovery")
+                .AddSystem(new FileDiscoverySystem(sourceDirectory)));
+
+            var fileHashes = new ConcurrentDictionary<string, string>();
+            pipelineBuilder.AddPipe(pb => pb
+                .Named("Hash Calculation")
+                .AddSystem(new HashCalculationSystem(fileHashes)));
+
+            pipelineBuilder.AddPipe(pb => pb
+                .Named("Duplicate Detection")
+                .AddSystem(new DuplicateDetectionSystem())
+                .AddSystem(new DuplicateLoggingSystem(logger)));
+
+            return pipelineBuilder.Build();
+        }
+    }
+}

--- a/DifferentialBackup/Program.cs
+++ b/DifferentialBackup/Program.cs
@@ -23,6 +23,7 @@ namespace DifferentialBackup
             Backup,
             Restore,
             Query,
+            Duplicate,
             Help
         }
 
@@ -65,6 +66,9 @@ namespace DifferentialBackup
                         break;
                     case Operation.Query:
                         PerformQuery(args.Skip(1).ToArray());
+                        break;
+                    case Operation.Duplicate:
+                        PerformDuplicateDetection(args.Skip(1).ToArray());
                         break;
                     case Operation.Help:
                     default:
@@ -415,6 +419,74 @@ namespace DifferentialBackup
             _pipelineLogger.Log("Query operation complete.");
         }
 
+        // --- Duplicate Detection Operation ---
+        static void PerformDuplicateDetection(string[] args)
+        {
+            if (_pipelineLogger == null) { Console.WriteLine("[FATAL ERROR] Logger not initialized. Cannot proceed."); return; }
+            _pipelineLogger.Log("Starting Duplicate Detection operation setup.");
+
+            string sourceDirectory;
+
+            if (args.Length >= 1)
+            {
+                sourceDirectory = args[0];
+                _pipelineLogger.Log($"Using command-line argument for Duplicate Detection: Source='{sourceDirectory}'");
+                Console.WriteLine("Using command-line argument for Duplicate Detection:");
+                Console.WriteLine($"Source Directory: {sourceDirectory}");
+            }
+            else
+            {
+                _pipelineLogger.Log("Insufficient command-line arguments. Prompting user for Duplicate Detection parameters.");
+                Console.WriteLine("Duplicate Detection requires a source directory.");
+                sourceDirectory = PromptForDirectory("Enter the Source Directory", mustExist: true);
+                if (string.IsNullOrEmpty(sourceDirectory)) return;
+                _pipelineLogger.Log($"User provided Duplicate Detection parameter: Source='{sourceDirectory}'");
+            }
+
+            if (!Directory.Exists(sourceDirectory))
+            {
+                _pipelineLogger.Log($"[ERROR] Source directory does not exist: '{sourceDirectory}'");
+                Console.WriteLine($"Error: Source directory not found: {sourceDirectory}");
+                return;
+            }
+
+            _pipelineLogger.Log("Initializing storage for Duplicate Detection.");
+            var storage = new ComponentStorage();
+            var root = new Entity();
+            storage.SetComponent(root, new FilePathComponent { FilePath = sourceDirectory });
+            var entities = new List<Entity> { root };
+
+            _pipelineLogger.Log("Building DuplicateDetection pipeline...");
+            var pipeline = DuplicateDetectionPipelineBuilder.BuildDuplicateDetectionPipeline(
+                sourceDirectory,
+                _pipelineLogger);
+
+            _pipelineLogger.Log("Executing DuplicateDetection pipeline...");
+            var result = pipeline.Execute(entities, storage);
+
+            if (result.IsSuccess)
+            {
+                var dupComponent = storage.GetComponent<DuplicateFilesComponent>(root);
+                if (dupComponent != null && dupComponent.Groups.Any())
+                {
+                    _pipelineLogger.Log($"Duplicate Detection finished. Found {dupComponent.Groups.Count} duplicate groups.");
+                    Console.WriteLine($"Found {dupComponent.Groups.Count} groups of duplicate files. See log for details.");
+                }
+                else
+                {
+                    _pipelineLogger.Log("Duplicate Detection finished. No duplicates found.");
+                    Console.WriteLine("No duplicate files found.");
+                }
+            }
+            else
+            {
+                _pipelineLogger.Log($"[ERROR] Duplicate Detection pipeline failed: {result.ErrorMessage}");
+                Console.WriteLine($"Duplicate detection failed: {result.ErrorMessage}");
+            }
+
+            _pipelineLogger.Log("Duplicate Detection operation complete.");
+        }
+
         // --- Helper Methods ---
 
         /// <summary>
@@ -535,12 +607,17 @@ namespace DifferentialBackup
             Console.WriteLine("           Arguments (Optional - will prompt if missing):");
             Console.WriteLine("             <BackupDestination>  Path where backup folders are stored.");
             Console.WriteLine();
+            Console.WriteLine("  duplicate Detects duplicate files in a directory and logs results.");
+            Console.WriteLine("           Arguments (Optional - will prompt if missing):");
+            Console.WriteLine("             <SourceDirectory>  Path to the directory to scan for duplicates.");
+            Console.WriteLine();
             Console.WriteLine("  help     Displays this help message.");
             Console.WriteLine();
             Console.WriteLine("Examples:");
             Console.WriteLine(@"  DifferentialBackup.exe backup ""C:\My Documents"" ""D:\Backups\MyDocs""");
             Console.WriteLine(@"  DifferentialBackup.exe restore ""D:\Backups\MyDocs"" ""C:\Restored Documents""");
             Console.WriteLine(@"  DifferentialBackup.exe query ""D:\Backups\MyDocs""");
+            Console.WriteLine(@"  DifferentialBackup.exe duplicate ""C:\My Documents""");
             Console.WriteLine(@"  DifferentialBackup.exe help");
             Console.WriteLine();
             Console.WriteLine("Data Files:");

--- a/DifferentialBackup/Systems/DuplicateDetectionSystem.cs
+++ b/DifferentialBackup/Systems/DuplicateDetectionSystem.cs
@@ -21,8 +21,10 @@ namespace DifferentialBackup.Systems
         public Result Execute(Entity entity, IComponentStorage storage)
         {
             // This system should only operate once on the root entity. Other entities
-            // represent individual files and are ignored here.
-            if (storage.HasComponent<FileHashComponent>(entity))
+            // represent individual files and are ignored here. We identify the root by
+            // checking that its FilePath points to a directory rather than a file.
+            var pathComponent = storage.GetComponent<FilePathComponent>(entity);
+            if (pathComponent == null || File.Exists(pathComponent.FilePath))
             {
                 return Result.Success();
             }

--- a/DifferentialBackup/Systems/DuplicateDetectionSystem.cs
+++ b/DifferentialBackup/Systems/DuplicateDetectionSystem.cs
@@ -1,0 +1,62 @@
+using DOPipeline.Entities;
+using DOPipeline.Storage;
+using DOPipeline.Systems;
+using DOPipeline.Utilities;
+using DifferentialBackup.Components;
+using System;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace DifferentialBackup.Systems
+{
+    public class DuplicateDetectionSystem : ISystem
+    {
+        private List<List<string>>? _cachedGroups;
+        private bool _processed;
+
+        public DuplicateDetectionSystem()
+        {
+        }
+
+        public Result Execute(Entity entity, IComponentStorage storage)
+        {
+            // This system should only operate once on the root entity. Other entities
+            // represent individual files and are ignored here.
+            if (storage.HasComponent<FileHashComponent>(entity))
+            {
+                return Result.Success();
+            }
+
+            try
+            {
+                if (!_processed)
+                {
+                    var files = storage.GetAllEntities()
+                        .Where(e => storage.HasComponent<FileHashComponent>(e))
+                        .Select(e => new
+                        {
+                            Path = storage.GetComponent<FilePathComponent>(e)?.FilePath,
+                            Hash = storage.GetComponent<FileHashComponent>(e)?.CurrentHash
+                        })
+                        .Where(x => x.Path != null && x.Hash != null)
+                        .ToList();
+
+                    _cachedGroups = files
+                        .GroupBy(f => f.Hash)
+                        .Where(g => g.Count() > 1)
+                        .Select(g => g.Select(f => f.Path!).ToList())
+                        .ToList();
+
+                    _processed = true;
+                }
+
+                storage.SetComponent(entity, new DuplicateFilesComponent { Groups = _cachedGroups ?? new List<List<string>>() });
+                return Result.Success();
+            }
+            catch (Exception ex)
+            {
+                return Result.Fail($"Failed to detect duplicates: {ex.Message}");
+            }
+        }
+    }
+}

--- a/DifferentialBackup/Systems/DuplicateLoggingSystem.cs
+++ b/DifferentialBackup/Systems/DuplicateLoggingSystem.cs
@@ -1,0 +1,53 @@
+using DOPipeline.Entities;
+using DOPipeline.Storage;
+using DOPipeline.Systems;
+using DifferentialBackup.Components;
+using DOPipeline.Logging;
+using DOPipeline.Utilities;
+using System.Linq;
+using System;
+
+namespace DifferentialBackup.Systems
+{
+    public class DuplicateLoggingSystem : ISystem
+    {
+        private readonly IPipelineLogger _logger;
+        private bool _logged;
+
+        public DuplicateLoggingSystem(IPipelineLogger logger)
+        {
+            _logger = logger;
+        }
+
+        public Result Execute(Entity entity, IComponentStorage storage)
+        {
+            // Only log once on root entity
+            if (_logged || storage.HasComponent<FileHashComponent>(entity))
+            {
+                return Result.Success();
+            }
+
+            try
+            {
+                var dupComponent = storage.GetComponent<DuplicateFilesComponent>(entity);
+                if (dupComponent != null && dupComponent.Groups.Any())
+                {
+                    foreach (var group in dupComponent.Groups)
+                    {
+                        _logger.Log($"Duplicate files: {string.Join(", ", group)}");
+                    }
+                }
+                else
+                {
+                    _logger.Log("No duplicate files found.");
+                }
+                _logged = true;
+                return Result.Success();
+            }
+            catch (Exception ex)
+            {
+                return Result.Fail($"Failed to log duplicates: {ex.Message}");
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 - **Backup:** Perform differential backups by only copying changed files, optimizing storage and time.
 - **Restore:** Restore files from a specific backup date, ensuring data integrity and availability.
 - **Query:** List all available backup dates for easy management and selection.
+- **Duplicate Detection:** Identify groups of duplicate files within a directory and log them.
 - **Interactive Prompts:** User-friendly prompts for required inputs when command-line arguments are not provided.
 - **Data Persistence:** Maintains file hashes and backup dates for efficient backup operations.
 
@@ -186,6 +187,22 @@ DifferentialBackup.exe query <BackupDestination>
 
 ```bash
 DifferentialBackup.exe query "D:\Backups\SourceBackup"
+```
+
+#### Duplicate Detection
+
+Scan a directory for duplicate files and log the results.
+
+##### Command
+
+```bash
+DifferentialBackup.exe duplicate <SourceDirectory>
+```
+
+##### Example
+
+```bash
+DifferentialBackup.exe duplicate "C:\My Documents"
 ```
 
 #### Help


### PR DESCRIPTION
## Summary
- log duplicate groups using pipeline logger
- supply logger to duplicate detection system
- verify duplicate messages appear in log files
- document logging in README
- skip duplicate detection for file entities so Execute only operates on the root
- update tests to ensure only root has duplicate results
- cache duplicate groups on first execution and handle sets of two or more duplicates
- expand tests to verify duplicate groups with three matching files
- add `duplicate` operation to CLI, docs, and Program.cs


------
https://chatgpt.com/codex/tasks/task_e_683f53c3fc8483269117d05bf75229f6