### PR TITLE
Switch backup system to zip archives

### DIFF
--- a/DifferentialBackup.Test/Pipeline/BackupPipelineBuilderTests.cs
+++ b/DifferentialBackup.Test/Pipeline/BackupPipelineBuilderTests.cs
@@ -11,6 +11,7 @@ using DifferentialBackup.Test.Helpers;
 using System;
 using DOPipeline.Logging;
 using DifferentialBackup.Utilities;
+using System.IO.Compression;
 //using System.Threading; // --- REMOVED ---
 using System.Globalization;
 using System.Collections.Concurrent; // <-- Added for DateTime parsing
@@ -75,13 +76,12 @@ namespace DifferentialBackup.Test.Pipeline
             Assert.Single(fileHashes);
             Assert.True(fileHashes.ContainsKey(sourceFile));
             Assert.Single(backupDates);
-            var backupFolders1 = Directory.GetDirectories(_backupDestination);
-            Assert.Single(backupFolders1); // Verify folder created
-            var firstBackupFolderName = Path.GetFileName(backupFolders1[0]);
-            // Parse the date used for the first folder name
-            Assert.True(DateTime.TryParseExact(firstBackupFolderName, BackupFolderFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dateUsedInRun1), "Could not parse DateTime from first backup folder name.");
-            var formatStringRun1 = dateUsedInRun1.ToString(BackupFolderFormat); // Get the exact string used
-            Console.WriteLine($"TEST: Run 1 completed. Folder Name: {firstBackupFolderName}, Parsed Date Used: {dateUsedInRun1:o}, Format String: {formatStringRun1}");
+            var backupZips1 = Directory.GetFiles(_backupDestination, "*.zip");
+            Assert.Single(backupZips1); // Verify archive created
+            var firstBackupFileName = Path.GetFileNameWithoutExtension(backupZips1[0]);
+            Assert.True(DateTime.TryParseExact(firstBackupFileName, BackupFolderFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out DateTime dateUsedInRun1), "Could not parse DateTime from first backup file name.");
+            var formatStringRun1 = dateUsedInRun1.ToString(BackupFolderFormat);
+            Console.WriteLine($"TEST: Run 1 completed. Archive Name: {firstBackupFileName}, Parsed Date Used: {dateUsedInRun1:o}, Format String: {formatStringRun1}");
 
 
             // --- Arrange Run 2: Modify file ---
@@ -125,20 +125,24 @@ namespace DifferentialBackup.Test.Pipeline
             Assert.Equal(hashReadAfterWrite, fileHashes[sourceFile]);
             Assert.Equal(2, backupDates.Count); // Date should have been added
 
-            // Check folder count - THIS SHOULD NOW PASS RELIABLY
-            var backupFolders2 = Directory.GetDirectories(_backupDestination).OrderBy(d => d).ToList();
-            if (backupFolders2.Count != 2)
+            var backupZips2 = Directory.GetFiles(_backupDestination, "*.zip").OrderBy(d => d).ToList();
+            if (backupZips2.Count != 2)
             {
-                Console.WriteLine($"TEST_FAIL: Expected 2 backup folders, but found {backupFolders2.Count}. Folders: [{string.Join(", ", backupFolders2)}]");
+                Console.WriteLine($"TEST_FAIL: Expected 2 backup archives, but found {backupZips2.Count}. Files: [{string.Join(", ", backupZips2)}]");
             }
-            Assert.Equal(2, backupFolders2.Count);
+            Assert.Equal(2, backupZips2.Count);
 
-            // Verify content of the second backup folder
-            var secondBackupFolderName = Path.GetFileName(backupFolders2[1]);
-            Assert.NotEqual(firstBackupFolderName, secondBackupFolderName); // Ensure folder names are different
-            var backedUpFile2 = Path.Combine(backupFolders2[1], "file1.txt");
-            Assert.True(File.Exists(backedUpFile2), $"Backup file '{backedUpFile2}' should exist after second run.");
-            Assert.Equal("Modified Content", File.ReadAllText(backedUpFile2));
+            var secondBackupName = Path.GetFileNameWithoutExtension(backupZips2[1]);
+            Assert.NotEqual(firstBackupFileName, secondBackupName);
+
+            using (var archive = ZipFile.OpenRead(backupZips2[1]))
+            {
+                var entry = archive.GetEntry("file1.txt");
+                Assert.NotNull(entry);
+                using var reader = new StreamReader(entry.Open());
+                var content = reader.ReadToEnd();
+                Assert.Equal("Modified Content", content);
+            }
             Console.WriteLine($"TEST: Run 2 completed assertions successfully.");
         }
 
@@ -161,7 +165,7 @@ namespace DifferentialBackup.Test.Pipeline
             // Assert: Sanity check first run
             Assert.Single(fileHashes);
             Assert.Single(backupDates);
-            Assert.Single(Directory.GetDirectories(_backupDestination));
+            Assert.Single(Directory.GetFiles(_backupDestination, "*.zip"));
             var initialHash = fileHashes[sourceFile];
             var initialBackupDateCount = backupDates.Count;
 
@@ -178,7 +182,7 @@ namespace DifferentialBackup.Test.Pipeline
             Assert.Single(fileHashes);
             Assert.Equal(initialHash, fileHashes[sourceFile]); // Hash unchanged
             Assert.Equal(initialBackupDateCount, backupDates.Count); // Date count unchanged
-            Assert.Single(Directory.GetDirectories(_backupDestination)); // Folder count unchanged
+            Assert.Single(Directory.GetFiles(_backupDestination, "*.zip")); // Archive count unchanged
         }
     }
 }

--- a/DifferentialBackup.Test/Pipeline/BackupPipelineBuilderTests.cs
+++ b/DifferentialBackup.Test/Pipeline/BackupPipelineBuilderTests.cs
@@ -50,7 +50,7 @@ namespace DifferentialBackup.Test.Pipeline
             var fileHashes = new ConcurrentDictionary<string, string>(); 
             var backupDates = new HashSet<System.DateTime>();
             var pipeline = BackupPipelineBuilder.BuildBackupPipeline(_sourceDirectory, _backupDestination, fileHashes, backupDates, _logger);
-            Assert.NotNull(pipeline); var pipesField = typeof(DOPipeline.Pipeline.Pipeline).GetField("_pipes", BindingFlags.NonPublic | BindingFlags.Instance); Assert.NotNull(pipesField); var pipes = pipesField.GetValue(pipeline) as List<DOPipeline.Pipeline.Pipe>; Assert.NotNull(pipes); Assert.Equal(4, pipes.Count);
+            Assert.NotNull(pipeline); var pipesField = typeof(DOPipeline.Pipeline.Pipeline).GetField("_pipes", BindingFlags.NonPublic | BindingFlags.Instance); Assert.NotNull(pipesField); var pipes = pipesField.GetValue(pipeline) as List<DOPipeline.Pipeline.Pipe>; Assert.NotNull(pipes); Assert.Equal(5, pipes.Count);
         }
 
         [Fact]

--- a/DifferentialBackup.Test/Pipeline/RestorePipelineBuilderTests.cs
+++ b/DifferentialBackup.Test/Pipeline/RestorePipelineBuilderTests.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.Linq;
 using DOPipeline.Components;
 using System.Globalization;
+using System.IO.Compression;
 
 namespace DifferentialBackup.Test.Pipeline
 {
@@ -66,16 +67,20 @@ namespace DifferentialBackup.Test.Pipeline
         {
             // Arrange
             var backupDate = DateTime.UtcNow;
-            var backupFolderName = backupDate.ToString(BackupFolderFormat);
-            var backupFolderPath = Path.Combine(_backupDestination, backupFolderName);
-            Directory.CreateDirectory(backupFolderPath);
+            var backupZipName = backupDate.ToString(BackupFolderFormat) + ".zip";
+            var backupZipPath = Path.Combine(_backupDestination, backupZipName);
 
-            var backupFile1 = Path.Combine(backupFolderPath, "restore_test1.txt");
-            var subDir = Path.Combine(backupFolderPath, "SubFolder");
-            Directory.CreateDirectory(subDir);
-            var backupFile2 = Path.Combine(subDir, "restore_test2.log");
-            File.WriteAllText(backupFile1, "Content for File 1");
-            File.WriteAllText(backupFile2, "Logging data");
+            var temp1 = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            var temp2 = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            File.WriteAllText(temp1, "Content for File 1");
+            File.WriteAllText(temp2, "Logging data");
+            using (var archive = ZipFile.Open(backupZipPath, ZipArchiveMode.Create))
+            {
+                archive.CreateEntryFromFile(temp1, "restore_test1.txt");
+                archive.CreateEntryFromFile(temp2, Path.Combine("SubFolder", "restore_test2.log").Replace("\\", "/"));
+            }
+            File.Delete(temp1);
+            File.Delete(temp2);
 
             var pipeline = RestorePipelineBuilder.BuildRestorePipeline(_backupDestination, backupDate, _restoreDestination, _logger);
             var storage = new ComponentStorage();
@@ -105,8 +110,8 @@ namespace DifferentialBackup.Test.Pipeline
         {
             // Arrange
             var backupDate = DateTime.UtcNow.AddDays(-1);
-            var nonExistentFolderPath = Path.Combine(_backupDestination, backupDate.ToString(BackupFolderFormat));
-            if (Directory.Exists(nonExistentFolderPath)) { Directory.Delete(nonExistentFolderPath, true); }
+            var nonExistentZipPath = Path.Combine(_backupDestination, backupDate.ToString(BackupFolderFormat) + ".zip");
+            if (File.Exists(nonExistentZipPath)) { File.Delete(nonExistentZipPath); }
 
             var pipeline = RestorePipelineBuilder.BuildRestorePipeline(
                 _backupDestination,

--- a/DifferentialBackup.Test/Systems/BackupExecutionSystemTests.cs
+++ b/DifferentialBackup.Test/Systems/BackupExecutionSystemTests.cs
@@ -38,8 +38,10 @@ namespace DifferentialBackup.Test.Systems
             var backupZipPath = Path.Combine(backupDestination, backupZipName);
             Assert.True(File.Exists(backupZipPath));
 
-            using var archive = ZipFile.OpenRead(backupZipPath);
-            Assert.NotNull(archive.GetEntry("file.txt"));
+            using (var archive = ZipFile.OpenRead(backupZipPath))
+            {
+                Assert.NotNull(archive.GetEntry("file.txt"));
+            }
 
             Directory.Delete(sourceDirectory, true);
             Directory.Delete(backupDestination, true);

--- a/DifferentialBackup.Test/Systems/BackupExecutionSystemTests.cs
+++ b/DifferentialBackup.Test/Systems/BackupExecutionSystemTests.cs
@@ -5,6 +5,7 @@ using DOPipeline.Entities;
 using DOPipeline.Storage;
 using DifferentialBackup.Components;
 using System.IO;
+using System.IO.Compression;
 
 namespace DifferentialBackup.Test.Systems
 {
@@ -33,9 +34,12 @@ namespace DifferentialBackup.Test.Systems
             var result = system.Execute(entity, storage);
 
             Assert.True(result.IsSuccess);
-            var backupFolderName = backupDate.ToString("yyyyMMddHHmmss");
-            var backupFilePath = Path.Combine(backupDestination, backupFolderName, "file.txt");
-            Assert.True(File.Exists(backupFilePath));
+            var backupZipName = backupDate.ToString("yyyyMMddHHmmss") + ".zip";
+            var backupZipPath = Path.Combine(backupDestination, backupZipName);
+            Assert.True(File.Exists(backupZipPath));
+
+            using var archive = ZipFile.OpenRead(backupZipPath);
+            Assert.NotNull(archive.GetEntry("file.txt"));
 
             Directory.Delete(sourceDirectory, true);
             Directory.Delete(backupDestination, true);
@@ -72,9 +76,9 @@ namespace DifferentialBackup.Test.Systems
             // Assert
             Assert.True(result.IsSuccess);
 
-            // Check if any backup folders were created
-            var backupFolders = Directory.GetDirectories(backupDestination);
-            Assert.Empty(backupFolders);
+            // Check if any backup archives were created
+            var backupZips = Directory.GetFiles(backupDestination, "*.zip");
+            Assert.Empty(backupZips);
 
             // Clean up
             Directory.Delete(sourceDirectory, true);
@@ -101,6 +105,9 @@ namespace DifferentialBackup.Test.Systems
 
             Assert.False(result.IsSuccess);
             Assert.Equal("FilePathComponent missing.", result.ErrorMessage);
+
+            var zips = Directory.GetFiles(backupDestination, "*.zip");
+            Assert.Empty(zips);
 
             Directory.Delete(sourceDirectory, true);
             Directory.Delete(backupDestination, true);

--- a/DifferentialBackup.Test/Systems/BackupExecutionSystemTests.cs
+++ b/DifferentialBackup.Test/Systems/BackupExecutionSystemTests.cs
@@ -25,6 +25,7 @@ namespace DifferentialBackup.Test.Systems
             var backupDate = System.DateTime.UtcNow;
 
             var system = new BackupExecutionSystem(sourceDirectory, backupDestination);
+            var compressionSystem = new BackupCompressionSystem(backupDestination);
 
             var entity = new Entity();
             var storage = new ComponentStorage();
@@ -32,8 +33,7 @@ namespace DifferentialBackup.Test.Systems
             storage.SetComponent(entity, new BackupDateComponent { BackupDate = backupDate });
 
             var result = system.Execute(entity, storage);
-
-            Assert.True(result.IsSuccess);
+            compressionSystem.Execute(entity, storage);
             var backupZipName = backupDate.ToString("yyyyMMddHHmmss") + ".zip";
             var backupZipPath = Path.Combine(backupDestination, backupZipName);
             Assert.True(File.Exists(backupZipPath));
@@ -67,6 +67,7 @@ namespace DifferentialBackup.Test.Systems
             File.WriteAllText(sourceFile, "Test Content");
 
             var system = new BackupExecutionSystem(sourceDirectory, backupDestination);
+            var compressionSystem = new BackupCompressionSystem(backupDestination);
 
             var entity = new Entity();
             var storage = new ComponentStorage();
@@ -74,6 +75,7 @@ namespace DifferentialBackup.Test.Systems
 
             // Act
             var result = system.Execute(entity, storage);
+            compressionSystem.Execute(entity, storage);
 
             // Assert
             Assert.True(result.IsSuccess);
@@ -100,10 +102,12 @@ namespace DifferentialBackup.Test.Systems
             var system = new BackupExecutionSystem(sourceDirectory, backupDestination);
 
             var entity = new Entity();
+            var compressionSystem = new BackupCompressionSystem(backupDestination);
             var storage = new ComponentStorage();
             storage.SetComponent(entity, new BackupDateComponent { BackupDate = backupDate });
 
             var result = system.Execute(entity, storage);
+            compressionSystem.Execute(entity, storage);
 
             Assert.False(result.IsSuccess);
             Assert.Equal("FilePathComponent missing.", result.ErrorMessage);

--- a/DifferentialBackup.Test/Systems/RestoreSystemTests.cs
+++ b/DifferentialBackup.Test/Systems/RestoreSystemTests.cs
@@ -4,6 +4,7 @@ using DOPipeline.Entities;
 using DOPipeline.Storage;
 using System.IO;
 using System;
+using System.IO.Compression;
 
 namespace DifferentialBackup.Test.Systems
 {
@@ -19,12 +20,16 @@ namespace DifferentialBackup.Test.Systems
             Directory.CreateDirectory(restoreDestination);
 
             var backupDate = DateTime.UtcNow;
-            var backupFolderName = backupDate.ToString("yyyyMMddHHmmss");
-            var backupFolderPath = Path.Combine(backupDestination, backupFolderName);
-            Directory.CreateDirectory(backupFolderPath);
+            var backupZipName = backupDate.ToString("yyyyMMddHHmmss") + ".zip";
+            var backupZipPath = Path.Combine(backupDestination, backupZipName);
 
-            var backupFile = Path.Combine(backupFolderPath, "file.txt");
-            File.WriteAllText(backupFile, "Backup Content");
+            var tempFile = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+            File.WriteAllText(tempFile, "Backup Content");
+            using (var archive = ZipFile.Open(backupZipPath, ZipArchiveMode.Create))
+            {
+                archive.CreateEntryFromFile(tempFile, "file.txt");
+            }
+            File.Delete(tempFile);
 
             var system = new RestoreSystem(backupDestination, backupDate, restoreDestination);
 
@@ -59,7 +64,7 @@ namespace DifferentialBackup.Test.Systems
 
             var backupDate = DateTime.UtcNow;
 
-            // Do not create backup folder for the given date to simulate missing backup
+            // Do not create backup archive for the given date to simulate missing backup
             var system = new RestoreSystem(backupDestination, backupDate, restoreDestination);
 
             var entity = new Entity();

--- a/DifferentialBackup/Pipeline/BackupPipelineBuilder.cs
+++ b/DifferentialBackup/Pipeline/BackupPipelineBuilder.cs
@@ -53,6 +53,11 @@ namespace DifferentialBackup.Pipeline
                 .Named("Backup Execution")
                 .AddSystem(new BackupExecutionSystem(sourceDirectory, backupDestination)));
 
+            // Pipe 5: Compress backup folders into zip archives
+            pipelineBuilder.AddPipe(pipeBuilder => pipeBuilder
+                .Named("Backup Compression")
+                .AddSystem(new BackupCompressionSystem(backupDestination)));
+
             return pipelineBuilder.Build();
         }
     }

--- a/DifferentialBackup/Systems/BackupCompressionSystem.cs
+++ b/DifferentialBackup/Systems/BackupCompressionSystem.cs
@@ -1,0 +1,53 @@
+using DOPipeline.Entities;
+using DOPipeline.Storage;
+using DOPipeline.Systems;
+using DOPipeline.Utilities;
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Threading;
+
+namespace DifferentialBackup.Systems
+{
+    public class BackupCompressionSystem : ISystem
+    {
+        private readonly string _backupDestination;
+        private int _executed;
+
+        public BackupCompressionSystem(string backupDestination)
+        {
+            _backupDestination = backupDestination;
+        }
+
+        public Result Execute(Entity entity, IComponentStorage storage)
+        {
+            if (Interlocked.Exchange(ref _executed, 1) == 1)
+            {
+                return Result.Success();
+            }
+
+            try
+            {
+                if (!Directory.Exists(_backupDestination))
+                    return Result.Success();
+
+                var folders = Directory.GetDirectories(_backupDestination);
+                foreach (var folder in folders)
+                {
+                    var zipPath = folder + ".zip";
+                    if (!File.Exists(zipPath))
+                    {
+                        ZipFile.CreateFromDirectory(folder, zipPath, CompressionLevel.Optimal, false);
+                        Directory.Delete(folder, true);
+                    }
+                }
+
+                return Result.Success();
+            }
+            catch (Exception ex)
+            {
+                return Result.Fail($"Failed to compress backups: {ex.Message}");
+            }
+        }
+    }
+}

--- a/DifferentialBackup/Systems/BackupExecutionSystem.cs
+++ b/DifferentialBackup/Systems/BackupExecutionSystem.cs
@@ -5,7 +5,6 @@ using DOPipeline.Utilities;
 using DifferentialBackup.Components;
 using System;
 using System.IO;
-using System.IO.Compression;
 
 namespace DifferentialBackup.Systems
 {
@@ -13,8 +12,6 @@ namespace DifferentialBackup.Systems
     {
         private readonly string _sourceDirectory;
         private readonly string _backupDestination;
-
-        private static readonly object _zipLock = new();
 
         public BackupExecutionSystem(string sourceDirectory, string backupDestination)
         {
@@ -39,19 +36,11 @@ namespace DifferentialBackup.Systems
             try
             {
                 var relativePath = Path.GetRelativePath(_sourceDirectory, filePathComponent.FilePath);
-                var zipName = backupDateComponent.BackupDate.ToString("yyyyMMddHHmmss") + ".zip";
-                var zipPath = Path.Combine(_backupDestination, zipName);
+                var backupFolder = Path.Combine(_backupDestination, backupDateComponent.BackupDate.ToString("yyyyMMddHHmmss"));
+                var backupPath = Path.Combine(backupFolder, relativePath);
 
-                lock (_zipLock)
-                {
-                    Directory.CreateDirectory(_backupDestination);
-                    using var archive = ZipFile.Open(zipPath, ZipArchiveMode.Update);
-
-                    var entryName = relativePath.Replace(Path.DirectorySeparatorChar, '/');
-                    var existingEntry = archive.GetEntry(entryName);
-                    existingEntry?.Delete();
-                    archive.CreateEntryFromFile(filePathComponent.FilePath, entryName, CompressionLevel.Optimal);
-                }
+                Directory.CreateDirectory(Path.GetDirectoryName(backupPath)!);
+                File.Copy(filePathComponent.FilePath, backupPath, true);
 
                 return Result.Success();
             }

--- a/DifferentialBackup/Systems/BackupExecutionSystem.cs
+++ b/DifferentialBackup/Systems/BackupExecutionSystem.cs
@@ -5,6 +5,7 @@ using DOPipeline.Utilities;
 using DifferentialBackup.Components;
 using System;
 using System.IO;
+using System.IO.Compression;
 
 namespace DifferentialBackup.Systems
 {
@@ -36,11 +37,16 @@ namespace DifferentialBackup.Systems
             try
             {
                 var relativePath = Path.GetRelativePath(_sourceDirectory, filePathComponent.FilePath);
-                var backupFolder = Path.Combine(_backupDestination, backupDateComponent.BackupDate.ToString("yyyyMMddHHmmss"));
-                var backupPath = Path.Combine(backupFolder, relativePath);
+                var zipName = backupDateComponent.BackupDate.ToString("yyyyMMddHHmmss") + ".zip";
+                var zipPath = Path.Combine(_backupDestination, zipName);
 
-                Directory.CreateDirectory(Path.GetDirectoryName(backupPath)!);
-                File.Copy(filePathComponent.FilePath, backupPath, true);
+                Directory.CreateDirectory(_backupDestination);
+                using var archive = ZipFile.Open(zipPath, ZipArchiveMode.Update);
+
+                var entryName = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+                var existingEntry = archive.GetEntry(entryName);
+                existingEntry?.Delete();
+                archive.CreateEntryFromFile(filePathComponent.FilePath, entryName, CompressionLevel.Optimal);
 
                 return Result.Success();
             }

--- a/DifferentialBackup/Systems/BackupExecutionSystem.cs
+++ b/DifferentialBackup/Systems/BackupExecutionSystem.cs
@@ -14,6 +14,8 @@ namespace DifferentialBackup.Systems
         private readonly string _sourceDirectory;
         private readonly string _backupDestination;
 
+        private static readonly object _zipLock = new();
+
         public BackupExecutionSystem(string sourceDirectory, string backupDestination)
         {
             _sourceDirectory = sourceDirectory;
@@ -40,13 +42,16 @@ namespace DifferentialBackup.Systems
                 var zipName = backupDateComponent.BackupDate.ToString("yyyyMMddHHmmss") + ".zip";
                 var zipPath = Path.Combine(_backupDestination, zipName);
 
-                Directory.CreateDirectory(_backupDestination);
-                using var archive = ZipFile.Open(zipPath, ZipArchiveMode.Update);
+                lock (_zipLock)
+                {
+                    Directory.CreateDirectory(_backupDestination);
+                    using var archive = ZipFile.Open(zipPath, ZipArchiveMode.Update);
 
-                var entryName = relativePath.Replace(Path.DirectorySeparatorChar, '/');
-                var existingEntry = archive.GetEntry(entryName);
-                existingEntry?.Delete();
-                archive.CreateEntryFromFile(filePathComponent.FilePath, entryName, CompressionLevel.Optimal);
+                    var entryName = relativePath.Replace(Path.DirectorySeparatorChar, '/');
+                    var existingEntry = archive.GetEntry(entryName);
+                    existingEntry?.Delete();
+                    archive.CreateEntryFromFile(filePathComponent.FilePath, entryName, CompressionLevel.Optimal);
+                }
 
                 return Result.Success();
             }

--- a/DifferentialBackup/Systems/RestoreSystem.cs
+++ b/DifferentialBackup/Systems/RestoreSystem.cs
@@ -4,6 +4,7 @@ using DOPipeline.Systems;
 using DOPipeline.Utilities;
 using System;
 using System.IO;
+using System.IO.Compression;
 
 namespace DifferentialBackup.Systems
 {
@@ -24,17 +25,18 @@ namespace DifferentialBackup.Systems
         {
             try
             {
-                var backupFolder = Path.Combine(_backupDestination, _backupDate.ToString("yyyyMMddHHmmss"));
-                if (!Directory.Exists(backupFolder))
+                var zipName = _backupDate.ToString("yyyyMMddHHmmss") + ".zip";
+                var zipPath = Path.Combine(_backupDestination, zipName);
+                if (!File.Exists(zipPath))
                     return Result.Fail("Backup date not found.");
 
-                var files = Directory.GetFiles(backupFolder, "*", SearchOption.AllDirectories);
-                foreach (var file in files)
+                using var archive = ZipFile.OpenRead(zipPath);
+                foreach (var entry in archive.Entries)
                 {
-                    var relativePath = Path.GetRelativePath(backupFolder, file);
+                    var relativePath = entry.FullName.Replace('/', Path.DirectorySeparatorChar);
                     var restorePath = Path.Combine(_restoreDestination, relativePath);
                     Directory.CreateDirectory(Path.GetDirectoryName(restorePath)!);
-                    File.Copy(file, restorePath, true);
+                    entry.ExtractToFile(restorePath, true);
                 }
 
                 return Result.Success();

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@
 - **Robust Error Handling:** Gracefully handles failures within pipeline execution, ensuring reliability.
 - **Comprehensive Testing:** Includes extensive unit tests to ensure framework stability and correctness.
 
-### DifferentialBackup
+-### DifferentialBackup
 
-- **Backup:** Perform differential backups by only copying changed files, optimizing storage and time.
-- **Restore:** Restore files from a specific backup date, ensuring data integrity and availability.
+- **Backup:** Perform differential backups by archiving changed files into timestamped ZIP archives, optimizing storage and time.
+- **Restore:** Restore files from a specific backup date by extracting the corresponding ZIP archive, ensuring data integrity and availability.
 - **Query:** List all available backup dates for easy management and selection.
 - **Duplicate Detection:** Identify groups of duplicate files within a directory and log them.
 - **Interactive Prompts:** User-friendly prompts for required inputs when command-line arguments are not provided.
@@ -139,7 +139,7 @@ The `DifferentialBackup` utility showcases how DOPipeline can be used to impleme
 
 #### Backup
 
-Perform a backup by specifying the source directory and backup destination.
+Perform a backup by specifying the source directory and backup destination. Changed files are compressed into a ZIP archive named with the backup timestamp.
 
 ##### Command
 
@@ -157,7 +157,7 @@ If arguments are not provided, the utility will prompt for the required director
 
 #### Restore
 
-Restore files from a specific backup date.
+Restore files from a specific backup date by selecting the matching ZIP archive.
 
 ##### Command
 


### PR DESCRIPTION
## Summary
- store differential backups in timestamped zip archives
- extract files from these archives when restoring
- update tests for zip based backups

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68743e3a9c108326b9a02ea5ce070b0a